### PR TITLE
Use new cask property names

### DIFF
--- a/brew_cask_replacer.py
+++ b/brew_cask_replacer.py
@@ -15,7 +15,7 @@ except NameError:
     pass
 
 _CASKS_HOME = 'http://raw.github.com/caskroom/homebrew-cask/master/Casks/'
-_PROPERTY_NAMES = ['url', 'homepage', 'version', 'link']
+_PROPERTY_NAMES = ['url', 'homepage', 'name', 'version', 'app', 'pkg']
 _DIGITAL_TO_ENGLISH_ = {
     0: 'zero',
     1: 'one',


### PR DESCRIPTION
`link` is deprecated in favor of `app`. Also add `name` and `pkg`.
