### PR TITLE
Fixes for compatibility with python 2.7+ and latest homebrew version

### DIFF
--- a/brew_cask_replace.py
+++ b/brew_cask_replace.py
@@ -43,7 +43,7 @@ def generate_cask_token(application_path, application_name):
     brew_location, err = p.communicate()
     brew_location = brew_location.strip()
     if len(brew_location):
-        p = subprocess.Popen([brew_location + '/Library/Taps/caskroom/' +
+        p = subprocess.Popen([brew_location + '/Library/Taps/homebrew/' +
                               'homebrew-cask/developer/bin/' +
                               'generate_cask_token',
                               application_path], stdout=subprocess.PIPE,

--- a/brew_cask_replace.py
+++ b/brew_cask_replace.py
@@ -4,7 +4,6 @@
 import sys
 import os
 import argparse
-import commands
 import urllib2
 import subprocess
 from send2trash import send2trash
@@ -33,7 +32,7 @@ def parse_ignores(ignore_file_path):
 
 def is_installed_by_appstore(application_path):
     cmd = 'codesign -dvvv "{0}"'.format(application_path)
-    output = commands.getoutput(cmd)
+    output = subprocess.check_output(cmd, shell=True)
     return output.find('Authority=Apple Mac OS Application Signing') > 0
 
 


### PR DESCRIPTION
The `commands` module is deprecated and removed in 2.6. The functions were moved to `subprocess` so I updated the line so that this script can run on Python2.7+